### PR TITLE
Develop

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="deploymentTargetDropDown">
-    <targetSelectedWithDropDown>
+    <runningDeviceTargetSelectedWithDropDown>
       <Target>
-        <type value="QUICK_BOOT_TARGET" />
+        <type value="RUNNING_DEVICE_TARGET" />
         <deviceKey>
           <Key>
             <type value="VIRTUAL_DEVICE_PATH" />
-            <value value="C:\Users\aflormun\.android\avd\Nexus_5X_API_28_2.avd" />
+            <value value="C:\Users\Alex\.android\avd\Nexus_5X_API_27_POSITIVO.avd" />
           </Key>
         </deviceKey>
       </Target>
-    </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2021-11-09T15:53:34.195666300Z" />
+    </runningDeviceTargetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2021-11-11T10:45:21.294418Z" />
   </component>
 </project>

--- a/app/src/main/java/es/uniovi/eii/contacttracker/fragments/notifypositive/NotifyPositiveFragment.kt
+++ b/app/src/main/java/es/uniovi/eii/contacttracker/fragments/notifypositive/NotifyPositiveFragment.kt
@@ -88,7 +88,7 @@ class NotifyPositiveFragment : Fragment() {
                     Snackbar.LENGTH_LONG, binding.root, requireActivity())
             }
             notifyError.observe(viewLifecycleOwner) {
-                AndroidUtils.snackbar(getString(it), Snackbar.LENGTH_LONG,
+                AndroidUtils.snackbar(getString(it.first, it.second), Snackbar.LENGTH_LONG,
                     binding.root, requireActivity())
             }
         }

--- a/app/src/main/java/es/uniovi/eii/contacttracker/fragments/riskcontacts/RiskContactFragment.kt
+++ b/app/src/main/java/es/uniovi/eii/contacttracker/fragments/riskcontacts/RiskContactFragment.kt
@@ -100,7 +100,8 @@ class RiskContactFragment : Fragment() {
 
             /* EditText para la hora de la comprobación */
             txtCheckHour.setOnClickListener {
-                checkHourTimePicker.show(requireActivity().supportFragmentManager, "CheckHour")
+                if(!checkHourTimePicker.isAdded)
+                    checkHourTimePicker.show(requireActivity().supportFragmentManager, "CheckHour")
             }
 
             /* Botón para añadir una alarma de comprobación */

--- a/app/src/main/java/es/uniovi/eii/contacttracker/fragments/tracklocation/LocationAlarmsFragment.kt
+++ b/app/src/main/java/es/uniovi/eii/contacttracker/fragments/tracklocation/LocationAlarmsFragment.kt
@@ -149,10 +149,12 @@ class LocationAlarmsFragment : Fragment() {
         binding.apply {
             // TextFields para las horas de Inicio y de Fin.
             layoutCardLocationAlarm.txtStartAutoTracking.setOnClickListener{
-                startTimePicker.show(requireActivity().supportFragmentManager, "StartTime")
+                if(!startTimePicker.isAdded)
+                    startTimePicker.show(requireActivity().supportFragmentManager, "StartTime")
             }
             layoutCardLocationAlarm.txtEndAutoTracking.setOnClickListener{
-                endTimePicker.show(requireActivity().supportFragmentManager, "EndTime")
+                if(!endTimePicker.isAdded)
+                    endTimePicker.show(requireActivity().supportFragmentManager, "EndTime")
             }
             // Botón para añadir una nueva alarma
             layoutCardLocationAlarm.btnAddLocationAlarm.setOnClickListener{

--- a/app/src/main/java/es/uniovi/eii/contacttracker/repositories/LocationRepository.kt
+++ b/app/src/main/java/es/uniovi/eii/contacttracker/repositories/LocationRepository.kt
@@ -55,8 +55,9 @@ class LocationRepository @Inject constructor(
     }
 
     /**
-     * Devuelve las localizaciones del usuario registradas desde la fecha pasada
-     * como parámetro hasta el día de hoy.
+     * Devuelve las localizaciones del usuario registradas en los últimos
+     * días indicados por el n.º de días pasado como parámetro tomando
+     * como referencia la fecha pasada como parámetro.
      *
      * @param lastDays N.º de días atrás para consultar las localizaciones.
      * @param date Fecha de referencia.

--- a/app/src/main/java/es/uniovi/eii/contacttracker/util/DateUtils.kt
+++ b/app/src/main/java/es/uniovi/eii/contacttracker/util/DateUtils.kt
@@ -7,6 +7,7 @@ import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.util.*
+import java.util.concurrent.TimeUnit
 import kotlin.math.abs
 
 /**
@@ -162,6 +163,15 @@ object DateUtils {
      * @param date2 Fecha 2.
      */
     fun getDaysBetweenDates(date1: Date, date2: Date): Long {
-        return abs(Duration.between(date1.toInstant(), date2.toInstant()).toDays())
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            abs(Duration.between(date1.toInstant(), date2.toInstant()).toDays())
+        } else {
+            val c1 = Calendar.getInstance()
+            val c2 = Calendar.getInstance()
+            c1.time = date1
+            c2.time = date2
+            val millisDiff = abs(c1.timeInMillis - c2.timeInMillis)
+            TimeUnit.MILLISECONDS.toDays(millisDiff)
+        }
     }
 }

--- a/app/src/main/java/es/uniovi/eii/contacttracker/viewmodels/NotifyPositiveViewModel.kt
+++ b/app/src/main/java/es/uniovi/eii/contacttracker/viewmodels/NotifyPositiveViewModel.kt
@@ -46,10 +46,11 @@ class NotifyPositiveViewModel @Inject constructor(
 
     /**
      * LiveData con el código del String que representa un error determinado
-     * en la notificación del positivo.
+     * en la notificación del positivo. Es un Par de tipo Int por si en algún
+     * error es necsario mostrar algún valor.
      */
-    private val _notifyError = SingleLiveEvent<Int>()
-    val notifyError: LiveData<Int> = _notifyError
+    private val _notifyError = SingleLiveEvent<Pair<Int, Int?>>()
+    val notifyError: LiveData<Pair<Int, Int?>> = _notifyError
 
     /**
      * LiveData para el icono de Carga.
@@ -137,15 +138,17 @@ class NotifyPositiveViewModel @Inject constructor(
 
     /**
      * Procesa el error de notificación de positivo devolviendo el código
-     * del string correspondiente al error.
+     * del string correspondiente al error y un valor Int si es aplicable.
      */
-    private fun processError(error: Error): Int {
+    private suspend fun processError(error: Error): Pair<Int, Int?> {
+        // Recuperar la configuración de notificación
+        val config = configRepository.getNotifyPositiveConfig()
         return when(error) {
-            Error.TIMEOUT -> R.string.network_error
-            Error.CANNOT_NOTIFY -> R.string.genericErrorNotifyPositive
-            Error.NOTIFICATION_LIMIT_EXCEEDED -> R.string.errorNotifyLimitExceeded
-            Error.NO_LOCATIONS_TO_NOTIFY -> R.string.errorNotifyNoLocations
-            else -> R.string.genericError
+            Error.TIMEOUT -> Pair(R.string.network_error, null)
+            Error.CANNOT_NOTIFY -> Pair(R.string.genericErrorNotifyPositive, null)
+            Error.NOTIFICATION_LIMIT_EXCEEDED -> Pair(R.string.errorNotifyLimitExceeded, config.notifyWaitTime)
+            Error.NO_LOCATIONS_TO_NOTIFY -> Pair(R.string.errorNotifyNoLocations, null)
+            else -> Pair(R.string.genericError, null)
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -149,7 +149,7 @@
     <string name="addPersonalData">Adjuntar mis datos personales</string>
     <string name="loadingPlaceholderNotifyPositive">Subiendo tus localizaciones a la nube...</string>
     <string name="notifyPositiveResultText">Se han subido %d localizaciones a la nube.</string>
-    <string name="errorNotifyLimitExceeded">Se ha superado el límite de notificación de positivos. No podrás notificar más positivos hasta pasados unos días.</string>
+    <string name="errorNotifyLimitExceeded">Se ha superado el límite de notificación. No podrás notificar más positivos hasta pasados %d días.</string>
     <string name="errorNotifyNoLocations">No se ha podido notificar el positivo: no existen localizaciones registradas en el periodo de infectividad. Activa el servicio de rastreo para registrar localizaciones.</string>
     <string name="seePrivacyPolicy">Consulta nuestra</string>
 


### PR DESCRIPTION
Solucionados problemas de los fragments de los TimePickers para que solo se muestren si no estaban ya añadidos. Además, en el Snackbar de error de superación de límite de notificación de positivos ahora se muestra el n.º de días que hay que esperar para poder notificar otro positivo.